### PR TITLE
Added build-base due to gcc error

### DIFF
--- a/lab1-info-introspection/Dockerfile
+++ b/lab1-info-introspection/Dockerfile
@@ -1,12 +1,13 @@
 FROM alpine:3.7
 MAINTAINER Davide Cioccia <d.cioccia@dcodx.com>
 RUN apk update --no-cache && apk add python3 \
-python3-dev \
-py3-pip \ 
-bash
+  python3-dev \
+  py3-pip \
+  bash \
+  build-base
 
 COPY . /app
 WORKDIR /app
-RUN pip3 install -r requirements.txt 
+RUN pip3 install -r requirements.txt
 RUN python3 populate-database.py
 CMD [ "python3", "app.py"]


### PR DESCRIPTION
During the docker build I received this error:

```
gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Os -fomit-frame-pointer -g -Os -fomit-frame-pointer -g -Os -fomit-frame-pointer -g -DTHREAD_STACK_SIZE=0x100000 -fPIC -I/usr/include/python3.6m -c src/greenlet/greenlet.c -o build/temp.linux-x86_64-3.6/src/greenlet/greenlet.o
    unable to execute 'gcc': No such file or directory
    error: command 'gcc' failed with exit status 1
```
    
This PR adds `build-base` to the packages installed which include `gcc` and its dependencies.